### PR TITLE
Document status page badges

### DIFF
--- a/docs.json
+++ b/docs.json
@@ -33,14 +33,14 @@
                 "pages": [
                   "v3.x/guide/incidents",
                   "v3.x/guide/components",
-                  "v3.x/guide/status-badges",
                   "v3.x/guide/schedules",
                   "v3.x/guide/metrics",
                   "v3.x/guide/subscribers",
                   "v3.x/guide/webhooks",
                   "v3.x/guide/mcp",
                   "v3.x/guide/users",
-                  "v3.x/guide/dashboard"
+                  "v3.x/guide/dashboard",
+                  "v3.x/guide/status-badges"
                 ]
               },
               {

--- a/docs.json
+++ b/docs.json
@@ -33,6 +33,7 @@
                 "pages": [
                   "v3.x/guide/incidents",
                   "v3.x/guide/components",
+                  "v3.x/guide/status-badges",
                   "v3.x/guide/schedules",
                   "v3.x/guide/metrics",
                   "v3.x/guide/subscribers",

--- a/v3.x/guide/status-badges.mdx
+++ b/v3.x/guide/status-badges.mdx
@@ -1,0 +1,42 @@
+---
+title: 'Status badges'
+description: 'Embed the current Cachet system or component status in an SVG badge.'
+icon: 'badge-check'
+---
+
+Cachet can generate cacheable SVG badges that show the current overall status or the status of an individual component.
+Use these badges in a README, project page, or any other place that supports an image URL.
+
+## Overall status badge
+
+Append `/badge.svg` to your status page URL:
+
+```html
+<img src="https://status.example.com/badge.svg" alt="Current system status" />
+```
+
+If Cachet is installed below a path, include that path in the URL. For example, an installation served at
+`https://example.com/status` has its badge at `https://example.com/status/badge.svg`.
+
+## Component status badge
+
+Append `/components/{component}/badge.svg`, replacing `{component}` with the component ID:
+
+```html
+<img src="https://status.example.com/components/1/badge.svg" alt="API status" />
+```
+
+Only enabled components that are publicly visible have badges. A badge request for a disabled component or a component
+in a non-public group returns `404 Not Found`.
+
+## Badge styles
+
+Choose a style by passing the `style` query parameter. Cachet supports `flat-square` (the default), `plastic-flat`,
+`flat`, `plastic`, `social`, and `svg`.
+
+```html
+<img src="https://status.example.com/components/1/badge.svg?style=flat" alt="API status" />
+```
+
+Badge responses are cached for 60 seconds, so they remain current without requiring every visitor to trigger a new
+render.


### PR DESCRIPTION
## Summary

Documents the new SVG status badge endpoints for Cachet 3.x.

- Adds a Status badges guide page to the navigation.
- Covers overall and component badge URLs, including installations hosted below `/status`.
- Documents availability safeguards, supported styles, and the 60-second cache lifetime.

## Validation

- `jq empty docs.json`
- `git diff --check`