### PR TITLE
Document custom image upload settings

### DIFF
--- a/v3.x/configuration/environment.mdx
+++ b/v3.x/configuration/environment.mdx
@@ -37,6 +37,16 @@ and served, rather than the content of your status page.
 | `CACHET_BEACON` | `true` | Whether Cachet sends anonymous [telemetry](/v3.x/configuration/beacon). Set to `false` to opt out. |
 | `CACHET_SETTINGS_CACHE` | `true` | Cache Cachet's settings instead of reading them from the database on every request. |
 
+## Image uploads
+
+These variables control custom images uploaded from the Cachet dashboard:
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `CACHET_UPLOAD_DISK` | `public` | The Laravel filesystem disk used to store and load custom images. Existing images must be moved when changing disks. |
+| `CACHET_UPLOAD_MAX_SIZE` | `1024` | The maximum image upload size in kilobytes. |
+| `CACHET_UPLOAD_IMAGE_MIME_TYPES` | `image/jpeg,image/png,image/gif,image/webp` | Comma-separated list of accepted image MIME types. |
+
 ## Maintenance & retention
 
 | Variable | Default | Description |

--- a/v3.x/configuration/theme.mdx
+++ b/v3.x/configuration/theme.mdx
@@ -20,6 +20,10 @@ To override the default banner image shown at the top of your status page, uploa
     We recommend using an image with a 16:9 aspect ratio for the best results.
 </Tip>
 
+The uploaded image is also embedded in outgoing Cachet emails as the application logo. Cachet accepts JPEG, PNG, GIF,
+and WebP images up to 1 MB by default. You can change the storage disk, maximum upload size, and accepted image types
+with the [image upload environment variables](/v3.x/configuration/environment#image-uploads).
+
 Once you've uploaded your image, click the "Save" button to apply the changes.
 By default, Cachet stores images in `/storage/app/public`. To make the image accessible to the public, you'll need to run the following command:
 


### PR DESCRIPTION
## Summary

- document that the custom banner is embedded as the application logo in outgoing emails
- document the upload disk, maximum size, and accepted MIME type environment variables
- clarify defaults and the migration requirement when changing storage disks

Companion documentation for cachethq/core#441 and cachethq/core#436.